### PR TITLE
Add timezone to Dockerfile & docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN go build -o echgo
 
 FROM alpine:latest AS scratch
 
+RUN apk --no-cache add tzdata
+
+ENV TZ=Europe/Berlin
+
 COPY --from=build /tmp/go/src/app/echgo /tmp/go/src/app/files/* /go/src/app/
 WORKDIR /go/src/app/
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ services:
         container_name: echgo
         networks:
             - echgo_org
+        environment:
+            - TZ=Europe/Berlin
         volumes:
             - /etc/echgo/configuration:/go/src/app/files/configuration
             - /var/lib/echgo/notification:/go/src/app/files/notification
@@ -156,6 +158,8 @@ services:
         container_name: echgo
         networks:
             - echgo_org
+        environment:
+            - TZ=Europe/Berlin
         volumes:
             - /var/lib/echgo/notification:/go/src/app/files/notification
             - echgo_configuration:/go/src/app/files/configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
         container_name: echgo
         networks:
             - echgo_org
+        environment:
+            - TZ=Europe/Berlin
         volumes:
             - /etc/echgo/configuration:/go/src/app/files/configuration
             - /var/lib/echgo/notification:/go/src/app/files/notification


### PR DESCRIPTION
You can now specify your own time zone for the output in the console so that the time entries fit. By default, the following time zone is configured: Europe/Berlin.